### PR TITLE
Fix the settings externalpage URL

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -29,7 +29,7 @@ if ($hassiteconfig or has_capability('tool/capexplorer:view', context_system::in
     $ADMIN->add('roles', new admin_externalpage(
         'toolcapexplorer',
         get_string('pluginname', 'tool_capexplorer'),
-        "/{$CFG->admin}/tool/capexplorer/index.php",
+        "{$CFG->wwwroot}/{$CFG->admin}/tool/capexplorer/index.php",
         'tool/capexplorer:view'
     ));
 }


### PR DESCRIPTION
Without this patch, the URL works only if the Moodle is installed in the root directory of the domain.
